### PR TITLE
Feature/#3 야구장 등록, 전체 야구장 목록보기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     implementation 'com.mysql:mysql-connector-j:8.0.32'
+
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
 }
 
 test {

--- a/src/main/java/BaseBallApp.java
+++ b/src/main/java/BaseBallApp.java
@@ -1,4 +1,15 @@
+import dao.StadiumDAO;
+import db.DBConnection;
+import service.StadiumService;
+
 public class BaseBallApp {
+
+    private static final StadiumService stadiumService;
+
+    static {
+        stadiumService = new StadiumService(new StadiumDAO(DBConnection.getInstance()));
+    }
+
     public static void main(String[] args) {
 
     }

--- a/src/main/java/dao/StadiumDAO.java
+++ b/src/main/java/dao/StadiumDAO.java
@@ -81,7 +81,7 @@ public class StadiumDAO {
      * @param name
      * @throws SQLException
      */
-    public void deleteById(String name) throws SQLException {
+    public void deleteByName(String name) throws SQLException {
         String query = "DELETE FROM stadium WHERE name = ?";
 
         try (PreparedStatement statement = connection.prepareStatement(query)) {

--- a/src/main/java/dao/StadiumDAO.java
+++ b/src/main/java/dao/StadiumDAO.java
@@ -1,0 +1,105 @@
+package dao;
+
+import model.Stadium;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class StadiumDAO {
+
+    private final Connection connection;
+
+    public StadiumDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * Stadium 생성
+     *
+     * @param name
+     * @return Optional Stadium
+     * @throws SQLException
+     */
+    public Optional<Stadium> createStadium(String name) throws SQLException {
+        String query = "INSERT INTO stadium (name) VALUES (?)";
+
+        try (PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, name);
+
+            int rowCount = statement.executeUpdate();
+            if (rowCount > 0) return findStadiumByName(name);
+        }
+        return Optional.empty(); // error
+    }
+
+    /**
+     * Stadium 이름으로 검색
+     *
+     * @param name
+     * @return Optional Stadium
+     * @throws SQLException
+     */
+    public Optional<Stadium> findStadiumByName(String name) throws SQLException {
+        String query = "SELECT * FROM stadium WHERE name = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, name);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return Optional.of(Stadium.from(resultSet));
+                }
+            }
+        }
+        return Optional.empty(); // not found
+    }
+
+    /**
+     * Stadium 전체 목록 검색
+     * @return
+     * @throws SQLException
+     */
+    public List<Stadium> findAll() throws SQLException {
+        String query = "SELECT * FROM stadium";
+
+        List<Stadium> stadiums = new ArrayList<>();
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    stadiums.add(Stadium.from(resultSet));
+                }
+            }
+        }
+        return stadiums;
+    }
+
+    /**
+     * 이름으로 야구장 삭제하기
+     *
+     * @param name
+     * @throws SQLException
+     */
+    public void deleteById(String name) throws SQLException {
+        String query = "DELETE FROM stadium WHERE name = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, name);
+            statement.executeUpdate();
+        }
+    }
+
+    /**
+     * 전체 야구장 삭제하기
+     *
+     * @throws SQLException
+     */
+    public void deleteAll() throws SQLException {
+        String query = "DELETE FROM stadium";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.executeUpdate();
+        }
+    }
+}

--- a/src/main/java/dto/stadium/StadiumRequest.java
+++ b/src/main/java/dto/stadium/StadiumRequest.java
@@ -1,0 +1,15 @@
+package dto.stadium;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StadiumRequest {
+
+    private String name;
+}

--- a/src/main/java/dto/stadium/StadiumResponse.java
+++ b/src/main/java/dto/stadium/StadiumResponse.java
@@ -1,0 +1,26 @@
+package dto.stadium;
+
+import lombok.*;
+import model.Stadium;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StadiumResponse {
+
+    private Long id;
+    private String name;
+    private Timestamp createAt;
+
+    public static StadiumResponse from(Stadium stadium) {
+        return StadiumResponse.builder()
+                .id(stadium.getId())
+                .name(stadium.getName())
+                .createAt(stadium.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/model/Stadium.java
+++ b/src/main/java/model/Stadium.java
@@ -1,0 +1,24 @@
+package model;
+
+import lombok.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Stadium {
+
+    private Long id;
+    private String name;
+    Timestamp createdAt;
+
+    public static Stadium from(ResultSet resultSet) throws SQLException {
+        return Stadium.builder()
+                .id(resultSet.getLong("id"))
+                .name(resultSet.getString("name"))
+                .createdAt(resultSet.getTimestamp("created_at"))
+                .build();
+    }
+}

--- a/src/main/java/service/StadiumService.java
+++ b/src/main/java/service/StadiumService.java
@@ -1,0 +1,83 @@
+package service;
+
+import dao.StadiumDAO;
+import dto.stadium.StadiumRequest;
+import dto.stadium.StadiumResponse;
+import model.Stadium;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class StadiumService {
+
+    private final StadiumDAO stadiumDAO;
+
+    public StadiumService(StadiumDAO stadiumDAO) {
+        this.stadiumDAO = stadiumDAO;
+    }
+
+    // 야구장 저장
+    public StadiumResponse save(StadiumRequest request) throws IllegalArgumentException {
+        String name = request.getName();
+        Optional<Stadium> result;
+
+        try {
+            result = stadiumDAO.createStadium(name);
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [insert]: " + exception.getMessage());
+        }
+        Stadium stadium = result.orElseThrow(() -> new IllegalArgumentException("Stadium save 실패"));
+
+        return StadiumResponse.from(stadium);
+    }
+
+    // 전체 야구장 검색
+    public List<StadiumResponse> findAll() {
+        try {
+            List<Stadium> stadiums = stadiumDAO.findAll();
+            return stadiums.stream()
+                    .map(StadiumResponse::from)
+                    .collect(Collectors.toList());
+
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [select All]: " + exception.getMessage());
+        }
+    }
+
+    // 야구장 이름으로 검색
+    public StadiumResponse findByName(StadiumRequest request) throws IllegalArgumentException {
+        String name = request.getName();
+        Optional<Stadium> result;
+
+        try {
+            result = stadiumDAO.findStadiumByName(name);
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [select]: " + exception.getMessage());
+        }
+        Stadium stadium = result.orElseThrow(() -> new IllegalArgumentException(name + "에 해당하는 경기장이 존재하지 않습니다."));
+
+        return StadiumResponse.from(stadium);
+    }
+
+    // 야구장 이름으로 삭제
+    public void deleteByName(StadiumRequest request) {
+        String name = request.getName();
+
+        try {
+            stadiumDAO.deleteById(name);
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [delete]: " + exception.getMessage());
+        }
+    }
+
+    // 전체 야구장 삭제
+    public void deleteAll() {
+        try {
+            stadiumDAO.deleteAll();
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [delete All]: " + exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/service/StadiumService.java
+++ b/src/main/java/service/StadiumService.java
@@ -66,7 +66,7 @@ public class StadiumService {
         String name = request.getName();
 
         try {
-            stadiumDAO.deleteById(name);
+            stadiumDAO.deleteByName(name);
         } catch (SQLException exception) {
             throw new IllegalArgumentException("SQL 에러 [delete]: " + exception.getMessage());
         }

--- a/src/test/java/service/StadiumServiceTest.java
+++ b/src/test/java/service/StadiumServiceTest.java
@@ -1,0 +1,71 @@
+package service;
+
+import dao.StadiumDAO;
+import db.DBConnection;
+import dto.stadium.StadiumRequest;
+import dto.stadium.StadiumResponse;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+
+class StadiumServiceTest {
+
+    private static final StadiumService stadiumService
+            = new StadiumService(new StadiumDAO(DBConnection.getInstance()));
+
+    @AfterAll
+    static void afterAll() {
+        stadiumService.deleteAll();
+    }
+
+    @BeforeEach
+    void setUp() {
+        stadiumService.deleteAll();
+    }
+
+    @DisplayName("stadiumService 야구장 삽입 성공 테스트")
+    @Test
+    void save_Success_Test() {
+        // Given
+        String expected = "Test Stadium";
+        StadiumRequest request = new StadiumRequest(expected);
+
+        // When
+        StadiumResponse actual = stadiumService.save(request);
+
+        // Then
+        Assertions.assertEquals(expected, actual.getName());
+    }
+
+    @DisplayName("stadiumService 야구장 삽입 실패 테스트")
+    @Test
+    void save_Failed_DuplicateName_Test() {
+        // Given
+        String expected = "Test Stadium";
+        StadiumRequest request = new StadiumRequest(expected);
+        stadiumService.save(request);
+
+        // When
+        // Then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            stadiumService.save(request);
+        });
+    }
+
+    @DisplayName("stadiumService 전체 야구장 검색 테스트")
+    @Test
+    void findAll_Success_Test() {
+        // Given
+        StadiumRequest request1 = new StadiumRequest("Test Stadium1");
+        stadiumService.save(request1);
+
+        StadiumRequest request2 = new StadiumRequest("Test Stadium2");
+        stadiumService.save(request2);
+
+        // When
+        List<StadiumResponse> actual = stadiumService.findAll();
+
+        // Then
+        Assertions.assertEquals(2, actual.size());
+    }
+}


### PR DESCRIPTION
요청 값에 따른 서비스 호출 분기에 대한 메인 로직은 배제하고
서비스의 요청과 응답만을 고려하여 구현

야구장 생성, 이름으로 검색, 전체 목록 검색, 이름으로 삭제, 전체 삭제 기능 구현

- StadiumService
모든 요청 값은 dto/stadium/`StadiumRequset`로 포장하여 전달
모든 응답 값은 dto/stadium/`StadiumResponse`로 포장하여 반환

- StadiumDTO
테스트 코드의 유연성과 추후 기능 확장 가능성을 고려하여
기본적인 CRUD 기능 모두 구현

closes #3 