### PR TITLE
Feature/#5 팀 등록, 전체 팀 목록 보기 구현

### DIFF
--- a/src/main/java/dao/TeamDAO.java
+++ b/src/main/java/dao/TeamDAO.java
@@ -58,7 +58,7 @@ public class TeamDAO {
 
     /**
      * Team 전체 목록 검색
-     * @return
+     * @return List Team
      * @throws SQLException
      */
     public List<Team> findAll() throws SQLException {
@@ -82,7 +82,7 @@ public class TeamDAO {
      * @param name
      * @throws SQLException
      */
-    public void deleteById(String name) throws SQLException {
+    public void deleteByName(String name) throws SQLException {
         String query = "DELETE FROM team WHERE name = ?";
 
         try (PreparedStatement statement = connection.prepareStatement(query)) {

--- a/src/main/java/dao/TeamDAO.java
+++ b/src/main/java/dao/TeamDAO.java
@@ -1,0 +1,106 @@
+package dao;
+
+import model.Team;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class TeamDAO {
+
+    private final Connection connection;
+
+    public TeamDAO(Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * Team 생성
+     *
+     * @param name
+     * @return Optional Team
+     * @throws SQLException
+     */
+    public Optional<Team> createTeam(String name, Long stadiumId) throws SQLException {
+        String query = "INSERT INTO team (name, stadium_id) VALUES (?, ?)";
+
+        try (PreparedStatement statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, name);
+            statement.setLong(2, stadiumId);
+
+            int rowCount = statement.executeUpdate();
+            if (rowCount > 0) return findTeamByName(name);
+        }
+        return Optional.empty(); // error
+    }
+
+    /**
+     * Team 이름으로 검색
+     *
+     * @param name
+     * @return Optional Team
+     * @throws SQLException
+     */
+    public Optional<Team> findTeamByName(String name) throws SQLException {
+        String query = "SELECT * FROM team WHERE name = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, name);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return Optional.of(Team.from(resultSet));
+                }
+            }
+        }
+        return Optional.empty(); // not found
+    }
+
+    /**
+     * Team 전체 목록 검색
+     * @return
+     * @throws SQLException
+     */
+    public List<Team> findAll() throws SQLException {
+        String query = "SELECT * FROM team";
+
+        List<Team> teams = new ArrayList<>();
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    teams.add(Team.from(resultSet));
+                }
+            }
+        }
+        return teams;
+    }
+
+    /**
+     * Team 이름으로 삭제하기
+     *
+     * @param name
+     * @throws SQLException
+     */
+    public void deleteById(String name) throws SQLException {
+        String query = "DELETE FROM team WHERE name = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, name);
+            statement.executeUpdate();
+        }
+    }
+
+    /**
+     * Team 전체 삭제하기
+     *
+     * @throws SQLException
+     */
+    public void deleteAll() throws SQLException {
+        String query = "DELETE FROM team";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.executeUpdate();
+        }
+    }
+}

--- a/src/main/java/dto/team/TeamRequest.java
+++ b/src/main/java/dto/team/TeamRequest.java
@@ -1,0 +1,14 @@
+package dto.team;
+
+import lombok.*;
+
+public class TeamRequest {
+
+    @Getter @Setter @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    public static class Create {
+
+        private String name;
+        private Long stadiumId;
+    }
+}

--- a/src/main/java/dto/team/TeamResponse.java
+++ b/src/main/java/dto/team/TeamResponse.java
@@ -1,0 +1,25 @@
+package dto.team;
+
+import lombok.*;
+import model.Team;
+
+import java.sql.Timestamp;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class TeamResponse {
+
+    private Long id;
+    private String name;
+    private Long stadiumId;
+    private Timestamp createAt;
+
+    public static TeamResponse from(Team team) {
+        return TeamResponse.builder()
+                .id(team.getId())
+                .name(team.getName())
+                .stadiumId(team.getStadiumId())
+                .createAt(team.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/model/Team.java
+++ b/src/main/java/model/Team.java
@@ -1,0 +1,26 @@
+package model;
+
+import lombok.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Team {
+
+    private Long id;
+    private String name;
+    private Long stadiumId;
+    private Timestamp createdAt;
+
+    public static Team from(ResultSet resultSet) throws SQLException {
+        return Team.builder()
+                .id(resultSet.getLong("id"))
+                .name(resultSet.getString("name"))
+                .stadiumId(resultSet.getLong("stadium_id"))
+                .createdAt(resultSet.getTimestamp("created_at"))
+                .build();
+    }
+}

--- a/src/main/java/service/TeamService.java
+++ b/src/main/java/service/TeamService.java
@@ -1,0 +1,54 @@
+package service;
+
+import dao.TeamDAO;
+import dto.team.TeamRequest;
+import dto.team.TeamResponse;
+import lombok.RequiredArgsConstructor;
+import model.Team;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamDAO teamDAO;
+
+    public TeamResponse save(TeamRequest.Create request) {
+        Optional<Team> result;
+        String name = request.getName();
+        Long stadiumId = request.getStadiumId();
+
+        try {
+            result = teamDAO.createTeam(name, stadiumId);
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [insert]: " + exception.getMessage());
+        }
+        Team team = result.orElseThrow(() -> new IllegalArgumentException("Team save 실패"));
+
+        return TeamResponse.from(team);
+    }
+
+    public List<TeamResponse> findAll() {
+        try {
+            List<Team> result = teamDAO.findAll();
+            return result.stream()
+                    .map(TeamResponse::from)
+                    .collect(Collectors.toList());
+
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [find All]: " + exception.getMessage());
+        }
+    }
+
+    // 전체 야구장 삭제
+    public void deleteAll() {
+        try {
+            teamDAO.deleteAll();
+        } catch (SQLException exception) {
+            throw new IllegalArgumentException("SQL 에러 [delete All]: " + exception.getMessage());
+        }
+    }
+}

--- a/src/test/java/service/TeamServiceTest.java
+++ b/src/test/java/service/TeamServiceTest.java
@@ -1,0 +1,84 @@
+package service;
+
+import dao.TeamDAO;
+import db.DBConnection;
+import dto.team.TeamRequest;
+import dto.team.TeamResponse;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.util.List;
+
+class TeamServiceTest {
+
+    private static final TeamService teamService;
+
+    static {
+        Connection connection = DBConnection.getInstance();
+        TeamDAO teamDao = new TeamDAO(connection);
+
+        teamService = new TeamService(teamDao);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        teamService.deleteAll();
+    }
+
+    @BeforeEach
+    void setUp() {
+        teamService.deleteAll();
+    }
+
+    @DisplayName("teamService 팀 삽입 성공 테스트")
+    @Test
+    void save_Success_Test() {
+        // Given
+        String name = "test Team";
+        Long stadiumId = 1L;
+        TeamRequest.Create request = new TeamRequest.Create(name, stadiumId);
+
+        // When
+        TeamResponse actual = teamService.save(request);
+
+        // Then
+        Assertions.assertEquals(name, actual.getName());
+        Assertions.assertEquals(stadiumId, actual.getStadiumId());
+    }
+
+    @DisplayName("teamService 팀 삽입 실패 테스트")
+    @Test
+    void save_Failed_DuplicateName_Test() {
+        // Given
+        String name = "test Team";
+        Long stadiumId = 1L;
+        TeamRequest.Create request = new TeamRequest.Create(name, stadiumId);
+        teamService.save(request);
+
+        // When
+        // Then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> teamService.save(request));
+    }
+
+    @DisplayName("teamService 전체 팀 검색 테스트")
+    @Test
+    void findAll_Success_Test() {
+        // Given
+        String name1 = "test Team1";
+        Long stadiumId1 = 1L;
+        TeamRequest.Create request1 = new TeamRequest.Create(name1, stadiumId1);
+
+        String name2 = "test Team2";
+        Long stadiumId2 = 1L;
+        TeamRequest.Create request2 = new TeamRequest.Create(name2, stadiumId2);
+
+        teamService.save(request1);
+        teamService.save(request2);
+
+        // When
+        List<TeamResponse> actual = teamService.findAll();
+
+        // Then
+        Assertions.assertEquals(2, actual.size());
+    }
+}


### PR DESCRIPTION
요청 값에 따른 서비스 호출 분기에 대한 메인 로직은 배제하고
서비스의 요청과 응답만을 고려하여 구현

팀 생성, 전체 목록 검색, 전체 삭제 기능 구현

- TeamService
모든 요청 값은 dto/team/TeamRequset로 포장하여 전달
모든 응답 값은 dto/team/TeamResponse로 포장하여 반환

- TeamDTO
테스트 코드의 유연성과 추후 기능 확장 가능성을 고려하여
기본적인 CRUD 기능 모두 구현

- 추후 기능 확장 고려
팀 이름, 아이디로 검색 기능
팀 검색 시 야구장 정보를 함께 반환하는 기능
팀 저장 시 FK인 StadiumId가 존재하지 않는 경우 예외 처리

closes #5 