### PR TITLE
Feature/#12 Console 입력값 파싱에서의 오류 발생으로 인한 로직 변경

### DIFF
--- a/src/main/java/domain/Request.java
+++ b/src/main/java/domain/Request.java
@@ -5,11 +5,13 @@ import java.util.Map;
 public class Request {
 
     private final String header;
-    private final Map<String, String> body;
+    private Map<String, String> body;
+
+    public Request(String header) {
+        this.header = header;
+    }
 
     public Request(String header, Map<String, String> body) {
-        validateHeader(header);
-        validateBody(body);
         this.header = header;
         this.body = body;
     }
@@ -20,13 +22,5 @@ public class Request {
 
     public Map<String, String> getBody() {
         return body;
-    }
-
-    private void validateHeader(String header) {
-
-    }
-
-    private void validateBody(Map<String, String> body) {
-
     }
 }

--- a/src/main/java/util/RequestParser.java
+++ b/src/main/java/util/RequestParser.java
@@ -4,19 +4,40 @@ import domain.Request;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class RequestParser {
+
+    // "야구장등록?name=잠실야구장"과 같은 쿼리스트링이 포함된 요청 패턴
+    private static final Pattern REQUEST_WITH_QUERY_STRING_PATTERN
+            = Pattern.compile("^[가-힣]+\\?(?:[a-zA-Z0-9_-]+=[a-zA-Z0-9%_-]*&?)*$");
+
+    // "야구장목록"과 같은 쿼리스트링이 포함되지 않은 요청 패턴 (한글만 허용)
+    private static final Pattern REQUEST_WITHOUT_QUERY_STRING_PATTERN
+            = Pattern.compile("[가-힣]");
 
     // Suppresses default constructor, ensuring non-instantiability
     private RequestParser() {
     }
 
-    public static Request parse(String request) {
+    public static Request parse(String request) throws IllegalArgumentException {
+        validateRequest(request);
+
+        // 쿼리스트링 형식이 아닌 경우
+        if (!request.contains("?"))
+            return new Request(request);
+
         String header = request.substring(0, request.indexOf('?'));
         String bodyString = request.substring(request.indexOf('?') + 1);
         Map<String, String> body = parseBody(bodyString);
 
         return new Request(header, body);
+    }
+
+    private static void validateRequest(String request) throws IllegalArgumentException {
+        if (!(REQUEST_WITH_QUERY_STRING_PATTERN.matcher(request).find()
+                || REQUEST_WITHOUT_QUERY_STRING_PATTERN.matcher(request).find()))
+            throw new IllegalArgumentException("올바르지 않은 요청값 입니다.");
     }
 
     private static Map<String, String> parseBody(String bodyString) {
@@ -25,11 +46,8 @@ public class RequestParser {
         String[] bodyPairs = bodyString.split("&");
         for (String bodyPair : bodyPairs) {
             String[] keyValue = bodyPair.split("=");
-
             if (keyValue.length != 2) throw new IllegalArgumentException("Bad Request");
-            String key = keyValue[0];
-            String value = keyValue[1];
-            body.put(key, value);
+            body.put(keyValue[0], keyValue[1]);
         }
 
         return body;

--- a/src/test/java/util/RequestParserTest.java
+++ b/src/test/java/util/RequestParserTest.java
@@ -10,9 +10,9 @@ import java.util.Map;
 
 class RequestParserTest {
 
-    @DisplayName("파싱 성공 테스트")
+    @DisplayName("파싱 성공 테스트 - 쿼리 스트링 형식")
     @Test
-    void parse_Success_Test() {
+    void parse_Success_With_QueryString_Test() {
         // Given
         String consoleRequest = "선수등록?teamId=1&name=이대호&position=1루수";
 
@@ -32,14 +32,53 @@ class RequestParserTest {
         Assertions.assertEquals(expectedBody, actualBody);
     }
 
-    @DisplayName("파싱 실패 테스트")
+    @DisplayName("파싱 실패 테스트 - 쿼리 스트링 형식")
     @Test
-    void parse_Failed_Test() {
+    void parse_Failed_With_QueryString_Test() {
         // Given
         String consoleBadRequest = "선수등록?teamId=1&name==이대호&position=1루수";
 
         // When
         // Then
         Assertions.assertThrows(IllegalArgumentException.class, () -> RequestParser.parse(consoleBadRequest));
+    }
+
+    @DisplayName("파싱 실패 테스트 - 쿼리 스트링 형식")
+    @Test
+    void parse_Failed_With_QueryString_Test2() {
+        // Given
+        String consoleBadRequest = "선수등록1?teamId=1&name이대호&position=1루수";
+
+        // When
+        // Then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> RequestParser.parse(consoleBadRequest));
+    }
+
+    @DisplayName("파싱 성공 테스트 - 일반 형식")
+    @Test
+    void parse_Success_Without_QueryString_Test() {
+        // Given
+        String consoleRequest = "선수목록";
+
+        // When
+        String expectedHeader = "선수목록";
+        Request actual = RequestParser.parse(consoleRequest);
+
+        // Then
+        Assertions.assertEquals(expectedHeader, actual.getHeader());
+        Assertions.assertNull(actual.getBody());
+    }
+
+    @DisplayName("파싱 실패 테스트 - 일반 형식")
+    @Test
+    void parse_Failed_Without_QueryString_Test() {
+        // Given
+        String consoleBadRequest = "선수목록?";
+
+        // When
+        // Then
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            RequestParser.parse(consoleBadRequest);
+        });
     }
 }


### PR DESCRIPTION
정규식을 사용하여 요청을 검증하는 로직을 추가함
그에 따른 `Request` 클래스와 테스트 클래스가 일부 변경됨.

- Request
header만 초기화화는 생성자 추가 
body를 포함하지 않는 요청 데이터를 담기 위해 수정

- RequestParser
요청을 정규식을 사용하여 검증하는 로직 추가
검증 이후 쿼리스트링 방식 혹은 일반 요청으로 나누어 Request 객체 반환하도록 수정
요청 검증은 매우 빈번하게 발생할 것으로 예상되어 컴파일된 패턴을 상수로 선언

- RequestParserTest
변경된 로직에 따른 테스트 코드 수정

closes #12 